### PR TITLE
Move mysql storage to a docker volume.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 
 services:
   nrdb-dev:
@@ -15,8 +15,13 @@ services:
     container_name: nrdb-dev-db
     image: "mysql:5"
     restart: always
+    volumes:
+      - dbdata:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: passwd
       MYSQL_DATABASE: nrdb-dev
       MYSQL_USER: nrdb-dev
       MYSQL_PASSWORD: passwd
+
+volumes:
+  dbdata:


### PR DESCRIPTION
This should allow the db to be persistent between builds.

I moved the docker-compose version to 2 since the version of docker i'm using didn't support 3 (i'll look into that) and nothing in here seems 3 specific.