### PR TITLE
Listen on port 8080

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:8080>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-install zip pdo_mysql
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer 
-
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# Listen on port 8080 instead of 80 in order to allow local development against the private Oauth API.
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 COPY 000-default.conf /etc/apache2/sites-available
 
 # Allow composer to create cache
@@ -18,7 +19,7 @@ RUN chown -R www-data:www-data /var/www
 
 USER root
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["apache2-foreground"]
 

--- a/dev-parameters.yml
+++ b/dev-parameters.yml
@@ -43,6 +43,6 @@ parameters:
     oauth_test_client_secret: ~
     oauth_test_redirect_uri: ~
     images_path: ~
-    card_image_url: 'https://netrunnerdb.com/card_image'
+    card_image_url: 'https://assets.netrunnerdb.com/v1/'
 #    slack_webhook_url: ~
 #    slack_webhook_channel: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - nrdb-dev-db
     ports:
-      - "8080:80"
+      - "8080:8080"
     links:
       - nrdb-dev-db
     volumes:


### PR DESCRIPTION
Listen properly on port 8080 to allow local development against the private Oauth API.